### PR TITLE
Add nfs server tester image

### DIFF
--- a/nfs-server-tester/Dockerfile
+++ b/nfs-server-tester/Dockerfile
@@ -1,0 +1,9 @@
+FROM hyperhq/nfs-server
+MAINTAINER Hyper Developers <dev@hyper.sh>
+
+RUN mkdir /export && dd if=/dev/zero of=/vol bs=100M count=0 seek=1 && mkfs.ext4 /vol
+
+EXPOSE 2049/tcp
+ADD entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/nfs-server-tester/entrypoint.sh
+++ b/nfs-server-tester/entrypoint.sh
@@ -1,0 +1,62 @@
+#! /bin/bash
+
+id=1000
+ganesha_config="/ganesha.conf"
+mountpoints=$(df |grep '/dev/sd'|awk '{print $6}')
+
+function setup_local_export_dir() {
+  mkdir -p $1
+  mount /vol $1
+}
+
+function make_export() {
+  exportid=$1
+  path=$2
+  pseudo=$3
+
+cat >> ${ganesha_config} << EOL
+EXPORT
+{
+        # Export Id (mandatory, each EXPORT must have a unique Export_Id)
+        Export_Id = ${exportid};
+
+        # Exported path (mandatory)
+        Path = ${path};
+
+        # Pseudo Path (required for NFS v4)
+        Pseudo = ${pseudo};
+
+	# The Protocols allowed
+	Protocols = NFS4;
+
+        # Required for access (default is None)
+        # Could use CLIENT blocks instead
+        Access_Type = RW;
+        Squash = No_root_squash; # To enable/disable root squashing
+        SecType = "sys";  # Security flavors supported
+	Transports = TCP;
+        # Exporting FSAL
+        FSAL {
+                Name = VFS;
+        }
+}
+EOL
+}
+
+rm -f ${ganesha_config}
+
+cat >> ${ganesha_config} << EOL
+NFSV4
+{
+	# Graceless/Grace_Period (NFS v4 Grace Period Control)
+	Graceless = true;
+}
+EOL
+
+setup_local_export_dir /export
+make_export ${id} /export /export
+
+# run rpcbind as ganesha.nfsd requires it
+rpcbind
+
+/usr/bin/ganesha.nfsd -F -L /var/log/ganesha.log -f ${ganesha_config}

--- a/nfs-server/Dockerfile
+++ b/nfs-server/Dockerfile
@@ -1,10 +1,10 @@
 FROM fedora:25
 MAINTAINER Hyper Developers <dev@hyper.sh>
 
-RUN dnf install -y cmake gcc git gcc-c++ krb5-devel bison flex rpcbind
+RUN dnf install -y cmake gcc git gcc-c++ krb5-devel bison flex rpcbind iproute
 RUN mkdir /root/src; git clone --recursive -b V2.4-stable https://github.com/nfs-ganesha/nfs-ganesha.git /root/src/nfs-ganesha
 RUN cd /root/src/nfs-ganesha/src/; mkdir build; cd build; cmake -DUSE_FSAL_GPFS=OFF ..; make; make install
-RUN mkdir -p /var/lib/nfs/ganesha
+RUN mkdir -p /var/lib/nfs/ganesha /run/rpcbind/
 
 EXPOSE 2049/tcp
 ADD entrypoint.sh /


### PR DESCRIPTION
aufs graphdriver does not work well with nfs-ganesha. Create an ext4 loop mount to export so that we can test nfs volume support in ci.