### PR TITLE
new auto builder + uploader for fedora and centos

### DIFF
--- a/centos_builder_2/Dockerfile
+++ b/centos_builder_2/Dockerfile
@@ -1,0 +1,22 @@
+FROM       centos:7
+MAINTAINER Hyper Developers <dev@hyper.sh>
+
+RUN yum install -y epel-release && yum update -y && \
+	yum install -y @development-tools git centos-packager rpmdevtools \
+	automake autoconf gcc make glibc-devel glibc-devel.i686 device-mapper-devel pcre-devel libsepol-devel libselinux-devel systemd-devel sqlite-devel libvirt-devel \
+	gcc-c++ zlib-devel libcap-devel libattr-devel librbd1-devel libtool awscli && \
+	yum clean all
+RUN curl -sL https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -zxf -
+RUN /usr/sbin/useradd makerpm; usermod -a -G mock makerpm; su makerpm -c 'rpmdev-setuptree'
+
+ADD entrypoint.sh /home/makerpm/
+RUN mkdir -p ~makerpm/{hyperd,hyperstart} &&\
+	cd ~makerpm/hyperd && git init && git remote add origin https://github.com/hyperhq/hyperd.git && \
+	cd ~makerpm/hyperstart && git init && git remote add origin https://github.com/hyperhq/hyperstart.git && \
+	chown -R makerpm.makerpm ~makerpm/{hyperd,hyperstart}
+
+ENV PATH /usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+USER       makerpm
+WORKDIR    /home/makerpm
+ENTRYPOINT ["/home/makerpm/entrypoint.sh"]

--- a/centos_builder_2/entrypoint.sh
+++ b/centos_builder_2/entrypoint.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+HYPERD_REF=${HYPERD_REF:-heads/master}
+HYPERSTART_REF=${HYPERSTART_REF:-heads/master}
+BUILD=${BUILD:-yes}
+UPLOAD=${UPLOAD:-none}
+ACCESS=${AWS_ACCESSKEY:-none}
+SECRET=${AWS_SECRETKEY:-none}
+
+cd ~makerpm/hyperd
+echo "fetch hyperd ${HYPERD_REF}"
+git fetch origin +refs/${HYPERD_REF#ref/}:refs/remotes/origin/target
+git checkout -b target origin/target
+hyperd_version=$(grep AC_INIT configure.ac|cut -d, -f2 |tr -d ' []')
+git archive --format=tar.gz target > ~makerpm/rpmbuild/SOURCES/hyperd-${hyperd_version}.tar.gz
+cp package/centos/rpm/SPECS/* ~makerpm/rpmbuild/SPECS/
+
+cd ~makerpm/hyperstart
+echo "fetch hyperstart ${HYPERSTART_REF}"
+git fetch origin +refs/${HYPERSTART_REF#ref/}:refs/remotes/origin/target
+git checkout -b target origin/target
+hyperstart_version=$(grep AC_INIT configure.ac|cut -d, -f2 |tr -d ' []')
+git archive --format=tar.gz target > ~makerpm/rpmbuild/SOURCES/hyperstart-${hyperstart_version}.tar.gz
+
+cd ~makerpm/rpmbuild/SPECS/
+
+mkdir  -p ~makerpm/.aws
+cat > ~makerpm/.aws/config <<END
+[default]
+region = us-west-1
+END
+
+cat > ~makerpm/.aws/credentials <<END
+[default]
+aws_access_key_id = ${ACCESS}
+aws_secret_access_key = ${SECRET}
+END
+
+chmod og-rwx -R ~makerpm/.aws
+
+if [ "${BUILD}x" == "yesx" ]; then
+	echo Build packages...
+	rpmbuild -ba hyper-container.spec
+	rpmbuild -ba hyperstart.spec
+
+	if [ "${UPLOAD}x" != "nonex" ]; then
+		echo "Upload packages to ${UPLOAD}..."
+		for rpm in ~makerpm/rpmbuild/RPMS/x86_64/* ; do
+			aws s3 cp $rpm s3://hypercontainer-build/${UPLOAD}/$(basename $rpm)
+		done
+		for rpm in ~makerpm/rpmbuild/SRPMS/* ; do
+			aws s3 cp $rpm s3://hypercontainer-build/${UPLOAD}/$(basename $rpm)
+		done
+	fi
+fi
+
+if [ $# -gt 0 ] ; then
+	echo "now execute [$@]"
+	exec $@
+fi
+echo finished.

--- a/debian_builder_2/Dockerfile
+++ b/debian_builder_2/Dockerfile
@@ -1,0 +1,24 @@
+FROM       debian:jessie
+MAINTAINER Hyper Developers <dev@hyper.sh>
+
+RUN apt-get update &&\
+	apt-get install -y autoconf automake pkg-config dh-make cpio git \
+		libdevmapper-dev libsqlite3-dev libvirt-dev python-pip && \
+	pip install awscli && \
+	apt-get clean && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN curl -sL https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -zxf -
+
+RUN useradd makedeb && mkdir -p ~makedeb/.aws && chown -R makedeb.makedeb ~makedeb && chmod og-rw ~makedeb/.aws
+RUN mkdir -p /hypersrc/hyperd/../hyperstart &&\
+	cd /hypersrc/hyperd && git init && git remote add origin https://github.com/hyperhq/hyperd.git && \
+	cd /hypersrc/hyperstart && git init && git remote add origin https://github.com/hyperhq/hyperstart.git && \
+	chown makedeb.makedeb -R /hypersrc
+
+ENV PATH /usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ADD entrypoint.sh /
+
+USER makedeb
+WORKDIR /hypersrc
+ENTRYPOINT ["/entrypoint.sh"]
+DIR /hypersrc
+ENTRYPOINT ["/entrypoint.sh"]

--- a/debian_builder_2/entrypoint.sh
+++ b/debian_builder_2/entrypoint.sh
@@ -33,17 +33,17 @@ chmod og-rwx -R ~/.aws
 
 if [ "${BUILD}x" == "yesx" ]; then
 	echo Build packages...
-        cd /hypersrc/hyperd/package/ubuntu/hypercontainer
+        cd /hypersrc/hyperd/package/debian/hypercontainer
 	VERSION=${hyperd_version} BRANCH=target ./make-hypercontainer-deb.sh
-        cd /hypersrc/hyperd/package/ubuntu/hyperstart
+        cd /hypersrc/hyperd/package/debian/hyperstart
 	VERSION=${hyperstart_version} BRANCH=target ./make-hyperstart-deb.sh
 
 	if [ "${UPLOAD}x" != "nonex" ]; then
 		echo "Upload packages to ${UPLOAD}..."
-		for deb in /hypersrc/hyperd/package/ubuntu/hyperstart/*.deb; do
+		for deb in /hypersrc/hyperd/package/debian/hyperstart/*.deb; do
 			aws s3 cp $deb s3://hypercontainer-build/${UPLOAD}/$(basename $deb)
 		done
-		for deb in /hypersrc/hyperd/package/ubuntu/hypercontainer/*.deb; do
+		for deb in /hypersrc/hyperd/package/debian/hypercontainer/*.deb; do
 			aws s3 cp $deb s3://hypercontainer-build/${UPLOAD}/$(basename $deb)
 		done
 	fi

--- a/fedora_builder_2/Dockerfile
+++ b/fedora_builder_2/Dockerfile
@@ -1,0 +1,21 @@
+FROM       fedora:25
+MAINTAINER Hyper Developers <dev@hyper.sh>
+
+RUN dnf install -y @development-tools git fedora-packager rpmdevtools \
+	automake autoconf gcc make glibc-devel glibc-devel.i686 device-mapper-devel pcre-devel libsepol-devel libselinux-devel systemd-devel sqlite-devel libvirt-devel \
+	gcc-c++ zlib-devel libcap-devel libattr-devel librbd1-devel libtool awscli && \
+	dnf clean all
+RUN curl -sL https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -zxf -
+RUN /usr/sbin/useradd makerpm; usermod -a -G mock makerpm; su makerpm -c 'rpmdev-setuptree'
+
+ADD entrypoint.sh /home/makerpm/
+RUN mkdir -p ~makerpm/{hyperd,hyperstart} &&\
+	cd ~makerpm/hyperd && git init && git remote add origin https://github.com/hyperhq/hyperd.git && \
+	cd ~makerpm/hyperstart && git init && git remote add origin https://github.com/hyperhq/hyperstart.git && \
+	chown -R makerpm.makerpm ~makerpm/{hyperd,hyperstart}
+
+ENV PATH /usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+USER       makerpm
+WORKDIR    /home/makerpm
+ENTRYPOINT ["/home/makerpm/entrypoint.sh"]

--- a/fedora_builder_2/entrypoint.sh
+++ b/fedora_builder_2/entrypoint.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+HYPERD_REF=${HYPERD_REF:-heads/master}
+HYPERSTART_REF=${HYPERSTART_REF:-heads/master}
+BUILD=${BUILD:-yes}
+UPLOAD=${UPLOAD:-none}
+ACCESS=${AWS_ACCESSKEY:-none}
+SECRET=${AWS_SECRETKEY:-none}
+
+cd ~makerpm/hyperd
+echo "fetch hyperd ${HYPERD_REF}"
+git fetch origin +refs/${HYPERD_REF#ref/}:refs/remotes/origin/target
+git checkout -b target origin/target
+hyperd_version=$(grep AC_INIT configure.ac|cut -d, -f2 |tr -d ' []')
+git archive --format=tar.gz target > ~makerpm/rpmbuild/SOURCES/hyperd-${hyperd_version}.tar.gz
+cp package/centos/rpm/SPECS/* ~makerpm/rpmbuild/SPECS/
+
+cd ~makerpm/hyperstart
+echo "fetch hyperstart ${HYPERSTART_REF}"
+git fetch origin +refs/${HYPERSTART_REF#ref/}:refs/remotes/origin/target
+git checkout -b target origin/target
+hyperstart_version=$(grep AC_INIT configure.ac|cut -d, -f2 |tr -d ' []')
+git archive --format=tar.gz target > ~makerpm/rpmbuild/SOURCES/hyperstart-${hyperstart_version}.tar.gz
+
+cd ~makerpm/rpmbuild/SPECS/
+
+mkdir  -p ~makerpm/.aws
+cat > ~makerpm/.aws/config <<END
+[default]
+region = us-west-1
+END
+
+cat > ~makerpm/.aws/credentials <<END
+[default]
+aws_access_key_id = ${ACCESS}
+aws_secret_access_key = ${SECRET}
+END
+
+chmod og-rwx -R ~makerpm/.aws
+
+if [ "${BUILD}x" == "yesx" ]; then
+	echo Build packages...
+	rpmbuild -ba hyper-container.spec
+	rpmbuild -ba hyperstart.spec
+
+	if [ "${UPLOAD}x" != "nonex" ]; then
+		echo "Upload packages to ${UPLOAD}..."
+		for rpm in ~makerpm/rpmbuild/RPMS/x86_64/* ; do
+			aws s3 cp $rpm s3://hypercontainer-build/${UPLOAD}/$(basename $rpm)
+		done
+		for rpm in ~makerpm/rpmbuild/SRPMS/* ; do
+			aws s3 cp $rpm s3://hypercontainer-build/${UPLOAD}/$(basename $rpm)
+		done
+	fi
+fi
+
+if [ $# -gt 0 ] ; then
+	echo "now execute [$@]"
+	exec $@
+fi
+echo finished.

--- a/ubuntu_builder_2/Dockerfile
+++ b/ubuntu_builder_2/Dockerfile
@@ -1,0 +1,24 @@
+FROM       ubuntu:xenial
+MAINTAINER Hyper Developers <dev@hyper.sh>
+
+RUN apt-get update &&\
+	apt-get install -y autoconf automake pkg-config dh-make cpio git \
+		libdevmapper-dev libsqlite3-dev libvirt-dev python-pip && \
+	pip install awscli && \
+	apt-get clean && rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN curl -sL https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar -C /usr/local -zxf -
+
+RUN useradd makedeb && mkdir -p ~makedeb/.aws && chown -R makedeb.makedeb ~makedeb && chmod og-rw ~makedeb/.aws
+RUN mkdir -p /hypersrc/hyperd/../hyperstart &&\
+	cd /hypersrc/hyperd && git init && git remote add origin https://github.com/hyperhq/hyperd.git && \
+	cd /hypersrc/hyperstart && git init && git remote add origin https://github.com/hyperhq/hyperstart.git && \
+	chown makedeb.makedeb -R /hypersrc
+
+ENV PATH /usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ADD entrypoint.sh /
+
+USER makedeb
+WORKDIR /hypersrc
+ENTRYPOINT ["/entrypoint.sh"]
+DIR /hypersrc
+ENTRYPOINT ["/entrypoint.sh"]

--- a/ubuntu_builder_2/entrypoint.sh
+++ b/ubuntu_builder_2/entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+HYPERD_REF=${HYPERD_REF:-heads/master}
+HYPERSTART_REF=${HYPERSTART_REF:-heads/master}
+BUILD=${BUILD:-yes}
+UPLOAD=${UPLOAD:-none}
+ACCESS=${AWS_ACCESSKEY:-none}
+SECRET=${AWS_SECRETKEY:-none}
+
+cd /hypersrc/hyperd
+echo "fetch hyperd ${HYPERD_REF}"
+git fetch origin +refs/${HYPERD_REF#ref/}:refs/remotes/origin/target
+git checkout -b target origin/target
+hyperd_version=$(grep AC_INIT configure.ac|cut -d, -f2 |tr -d ' []')
+
+cd /hypersrc/hyperstart
+echo "fetch hyperstart ${HYPERSTART_REF}"
+git fetch origin +refs/${HYPERSTART_REF#ref/}:refs/remotes/origin/target
+git checkout -b target origin/target
+hyperstart_version=$(grep AC_INIT configure.ac|cut -d, -f2 |tr -d ' []')
+
+cat > ~/.aws/config <<END
+[default]
+region = us-west-1
+END
+
+cat > ~/.aws/credentials <<END
+[default]
+aws_access_key_id = ${ACCESS}
+aws_secret_access_key = ${SECRET}
+END
+chmod og-rwx -R ~/.aws
+
+if [ "${BUILD}x" == "yesx" ]; then
+	echo Build packages...
+        cd /hypersrc/hyperd/package/ubuntu/hypercontainer
+	VERSION=${hyperd_version} BRANCH=target ./make-hypercontainer-deb.sh
+        cd /hypersrc/hyperd/package/ubuntu/hyperstart
+	VERSION=${hyperstart_version} BRANCH=target ./make-hyperstart-deb.sh
+
+	if [ "${UPLOAD}x" != "nonex" ]; then
+		echo "Upload packages to ${UPLOAD}..."
+		for deb in /hypersrc/hyperd/package/ubuntu/hyperstart/*; do
+			aws s3 cp $deb s3://hypercontainer-build/${UPLOAD}/$(basename $deb)
+		done
+		for deb in /hypersrc/hyperd/package/ubuntu/hypercontainer/*; do
+			aws s3 cp $deb s3://hypercontainer-build/${UPLOAD}/$(basename $deb)
+		done
+	fi
+fi
+
+if [ $# -gt 0 ] ; then
+	echo "now execute [$@]"
+	exec $@
+fi
+echo finished.


### PR DESCRIPTION
specify the prefix in bucket (`test`) and correct aws credentials, RPMs will be uploaded to S3 `hypercontainer-build` bucket automatically 

CentOS:

```
docker run -it -e HYPERD_REF=pull/563/merge -e UPLOAD=test -e AWS_ACCESSKEY=AAAAAA -e AWS_SECRETKEY=fffffff+ppppp/k gnawux/buildenv:centos
```

Fedora

```
docker run -it -e HYPERD_REF=pull/563/merge -e UPLOAD=test -e AWS_ACCESSKEY=AAAAAA -e AWS_SECRETKEY=fffffff+ppppp/k gnawux/buildenv:fedora
```

Signed-off-by: Wang Xu <gnawux@gmail.com>